### PR TITLE
fix: line spacing of title when the home page is on mobile

### DIFF
--- a/src/pages/home/index.module.scss
+++ b/src/pages/home/index.module.scss
@@ -157,7 +157,7 @@ $headerZ: 2;
   @media (max-width: $mobileBreakPoint) {
     font-weight: 800;
     font-size: 50px;
-    line-height: 40px;
+    line-height: 80%;
     letter-spacing: -0.025em;
   }
 }


### PR DESCRIPTION
# Before
<img width="639" alt="image" src="https://user-images.githubusercontent.com/9160743/228732155-130ab5fc-2d7f-46dd-a5cf-e8e79e8385ec.png">

# After
<img width="768" alt="image" src="https://user-images.githubusercontent.com/9160743/228732165-06d47b03-6663-429e-ae2c-9e8652ec1cc7.png">
