### PR TITLE
fix wrong weblink directory ("blogs" to "knowledge-base")

### DIFF
--- a/src/pages/knowledge-base/[slug].page.tsx
+++ b/src/pages/knowledge-base/[slug].page.tsx
@@ -136,7 +136,7 @@ const Post = ({ post, recents, categories }: Props) => {
                 <div className={styles.title}>{`${t('recent_posts')}:`}</div>
                 <div className={styles.recents}>
                   {recents.map(b => (
-                    <Link key={b.title} href={`/blogs/${b.slug}`}>
+                    <Link key={b.title} href={`/knowledge-base/${b.slug}`}>
                       {b.title}
                     </Link>
                   ))}


### PR DESCRIPTION
The list of recent posts all linked to the wrong (outdated?) directory "/blogs/" instead of the currently used "/knowledge-base/" 

_Though, might not want to have a direct directory link here, in case it changes again in future(?)_