### PR TITLE
fix: distinguish the concept of excerpt from that of subtitle

### DIFF
--- a/src/pages/knowledge-base/[slug].page.tsx
+++ b/src/pages/knowledge-base/[slug].page.tsx
@@ -48,7 +48,7 @@ const Post = ({ post, recents, categories }: Props) => {
           ...props,
           type: 'article',
           title: post.title,
-          description: post.excerpt ?? '',
+          description: post.excerpt,
           ...(post.coverImage && {
             image: {
               alt: 'coverImage',
@@ -101,7 +101,7 @@ const Post = ({ post, recents, categories }: Props) => {
               <TOCItem id="post_title" className={styles.title} titleInTOC={post.title}>
                 {post.title}
               </TOCItem>
-              <div className={styles.excerpt}>{post.excerpt}</div>
+              <div className={styles.subtitle}>{post.subtitle}</div>
 
               {post.coverImage && (
                 <Image

--- a/src/pages/knowledge-base/knowledgeBase.module.scss
+++ b/src/pages/knowledge-base/knowledgeBase.module.scss
@@ -137,7 +137,7 @@ $linkColor: var(--colorSecond);
         line-height: 1.8rem;
       }
 
-      .excerpt {
+      .subtitle {
         margin: 10px 0 25px;
         color: #484d4e;
         font-weight: 200;

--- a/src/utils/blogs.ts
+++ b/src/utils/blogs.ts
@@ -13,6 +13,7 @@ export interface Blog {
   slug: string
   content: string
   title: string
+  subtitle?: string
   date: string
   readingTime: string
   authors: { name: string; avatar?: string }[]
@@ -21,7 +22,7 @@ export interface Blog {
     width?: number
     height?: number
   }
-  excerpt?: string
+  excerpt: string
   category?: string
   link?: string
 }
@@ -96,6 +97,7 @@ export async function getBlogBySlug<F extends (keyof Blog)[]>(
   })
 
   const title = getStringValue(data.title)
+  const subtitle = getStringValue(data.subtitle)
   const excerpt = getStringValue(data.excerpt) ?? (await getBlogExcerpt(content))
   const category = getStringValue(data.category)
   const link = getStringValue(data.link)
@@ -103,6 +105,7 @@ export async function getBlogBySlug<F extends (keyof Blog)[]>(
   const blog = omitNullValue({
     slug,
     title: title ?? slug,
+    subtitle,
     content,
     date,
     coverImage,
@@ -162,7 +165,7 @@ async function getBlogExcerpt(content: Blog['content']): Promise<Blog['excerpt']
   const contentHTML = await markdownToHtml(content)
   const parser = new DOMParser()
   const doc = parser.parseFromString(`<html><body>${contentHTML}</body></html>`, 'text/html')
-  return doc.documentElement.textContent?.substring(0, 200)
+  return (doc.documentElement.textContent ?? content).substring(0, 200)
 }
 
 function getStringValue(data: unknown): string | undefined {


### PR DESCRIPTION
Ref: #178 

fix: distinguish the concept of excerpt from that of subtitle

PR to correct fields in old articles: https://github.com/NervosEducationHub/EducationHubArticles/pull/28