### PR TITLE
chore: add CKB badge in banner text

### DIFF
--- a/src/pages/home/index.module.scss
+++ b/src/pages/home/index.module.scss
@@ -170,6 +170,25 @@ $headerZ: 2;
   }
 }
 
+.ckbBadge {
+  display: inline-block;
+  margin-left: 10px;
+  padding: 10px 10px 5px;
+  color: white;
+  font-weight: 600;
+  font-size: 46px;
+  line-height: 50px;
+  letter-spacing: 2px;
+  vertical-align: middle;
+  background-color: black;
+
+  @media (max-width: $mobileBreakPoint) {
+    font-size: 28px;
+    line-height: 80%;
+    letter-spacing: 1px;
+  }
+}
+
 .subjectTitleText {
   font-weight: 500;
   font-size: 25px;

--- a/src/pages/home/index.page.tsx
+++ b/src/pages/home/index.page.tsx
@@ -209,7 +209,7 @@ const SlideCKBIntro: FC<ScreenSlideProps> = props => {
       <div className={styles.slideCKBIntro}>
         <div className={clsx(styles.titleText, DISABLE_CGOL_MOUSE_CONTROLLER)}>
           {t('text1')}
-          <div className={clsx(styles.ckbBadge, DISABLE_CGOL_MOUSE_CONTROLLER)}>CKB</div>
+          <div className={styles.ckbBadge}>CKB</div>
         </div>
         <div className={clsx(styles.subjectTitleText, DISABLE_CGOL_MOUSE_CONTROLLER)}>{t('text2')}</div>
         <div className={clsx(styles.descriptionText, DISABLE_CGOL_MOUSE_CONTROLLER)}>{t('text3')}</div>

--- a/src/pages/home/index.page.tsx
+++ b/src/pages/home/index.page.tsx
@@ -207,7 +207,10 @@ const SlideCKBIntro: FC<ScreenSlideProps> = props => {
   return (
     <ScreenSlide {...props}>
       <div className={styles.slideCKBIntro}>
-        <div className={clsx(styles.titleText, DISABLE_CGOL_MOUSE_CONTROLLER)}>{t('text1')}</div>
+        <div className={clsx(styles.titleText, DISABLE_CGOL_MOUSE_CONTROLLER)}>
+          {t('text1')}
+          <div className={clsx(styles.ckbBadge, DISABLE_CGOL_MOUSE_CONTROLLER)}>CKB</div>
+        </div>
         <div className={clsx(styles.subjectTitleText, DISABLE_CGOL_MOUSE_CONTROLLER)}>{t('text2')}</div>
         <div className={clsx(styles.descriptionText, DISABLE_CGOL_MOUSE_CONTROLLER)}>{t('text3')}</div>
       </div>


### PR DESCRIPTION
## Description 

Resolve: https://github.com/Magickbase/nervos-official-website/issues/234

Figma: https://www.figma.com/proto/fMWK8ZGROCdfOa7nmmUDHz/Nervos.org-R4?page-id=0%3A1&type=design&node-id=3157-20827&viewport=1541%2C140%2C0.17&t=OGZi0G7J24K4uC9u-1&scaling=min-zoom

This PR adds a CKB badge to banner text, Preview:

- Desktop
<img width="500" alt="image" src="https://github.com/Magickbase/nervos-official-website/assets/3870972/b0d8c2af-839a-44d1-8a84-e28f3afdf6c3">


- Mobile
<img width="500" alt="image" src="https://github.com/Magickbase/nervos-official-website/assets/3870972/a4f4008e-d663-40a8-98e2-fd67365dc077">
