### PR TITLE
fix: exclude raw files from serverless function

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -69,6 +69,9 @@ const config = {
       permanent: false,
     }))
   },
+  experimental: {
+    outputFileTracingIgnores: ['public/education_hub_articles'],
+  },
 }
 
 /**


### PR DESCRIPTION
This configuration ignores `public/education_hub_articles` on uploading static files to serverless platform, so the raw markdown files won't be hosted and disk usage can be reduced.