### PR TITLE
feat: remove w3w link from media kit page

### DIFF
--- a/public/locales/en/media-kit.json
+++ b/public/locales/en/media-kit.json
@@ -40,6 +40,5 @@
     "title": "Nervos merch assets",
     "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
     "download": "Download all merch assets",
-    "link": "Visit our W3W merch store"
   }
 }

--- a/src/pages/media-kit/index.page.tsx
+++ b/src/pages/media-kit/index.page.tsx
@@ -175,10 +175,6 @@ const MediaKit: NextPage = () => {
         label: t('merchAssets.download'),
         link: 'https://drive.google.com/drive/folders/1ZSnT39fv1OoZ9ABUfDxt9SayQ2AEes22',
       },
-      link: {
-        label: t('merchAssets.link'),
-        link: 'https://w3w.ai/main/nervosnetwork',
-      },
       assets: (
         <div className={styles.merchAssets}>
           {illustration.merchAssets.map(asset => (


### PR DESCRIPTION
Before

<img width="1283" alt="image" src="https://github.com/user-attachments/assets/9399e98d-10a5-4eaf-90d8-7eb7ec5945b2" />


After

![image](https://github.com/user-attachments/assets/e3a4a9d4-f0b6-4edd-826c-a5b490b8f65b)
